### PR TITLE
 Set optopt=0, optarg=NULL for unrecognized long option.

### DIFF
--- a/test/tests_on_linux.sh
+++ b/test/tests_on_linux.sh
@@ -40,7 +40,7 @@ run_test() {
 }
 
 run_tests() {
-    for optstring in "ab:" ":ab:" "ab::" ":ab::" "+ab:" "+:ab:" ":+ab:" "-ab:" "-+ab:" "+-ab:" "-:ab:" ":-ab:"; do
+    for optstring in "" "ab:" ":ab:" "ab::" ":ab::" "+ab:" "+:ab:" ":+ab:" "-ab:" "-+ab:" "+-ab:" "-:ab:" ":-ab:"; do
 	for args in "" \
 	    "foo" \
 	    "-c" \

--- a/test/tests_on_linux.sh
+++ b/test/tests_on_linux.sh
@@ -15,6 +15,9 @@ run_test() {
     env OPTSTRING="$1" ./ya_getopt_test $2 2> ya_getopt_test.out
     env OPTSTRING="$1" ./ya_getopt_long_test $2 2> ya_getopt_long_test.out
     env OPTSTRING="$1" ./ya_getopt_long_only_test $2 2> ya_getopt_long_only_test.out
+    # Ignore some differences in error messages.
+    sed -i "s#option '-b' is ambiguous;.*--bar' '--baz'#unrecognized option '-b'#" \
+	getopt_long_test.out getopt_long_only_test.out
     # Compare the output files respectively.
     if ! cmp getopt_test.out ya_getopt_test.out >/dev/null; then
 	echo

--- a/ya_getopt.c
+++ b/ya_getopt.c
@@ -254,6 +254,9 @@ static int ya_getopt_longopts(int argc, char * const argv[], char *arg, const ch
     size_t namelen;
     int idx;
 
+    ya_optopt = 0;
+    ya_optarg = NULL;
+
     for (idx = 0; longopts[idx].name != NULL; idx++) {
         opt = &longopts[idx];
         namelen = strlen(opt->name);
@@ -264,7 +267,6 @@ static int ya_getopt_longopts(int argc, char * const argv[], char *arg, const ch
                 case ya_required_argument:
                     ya_optind++;
                     if (ya_optind == argc) {
-                        ya_optarg = NULL;
                         ya_optopt = opt->val;
                         ya_getopt_error(optstring, "%s: option '--%s' requires an argument\n", argv[0], opt->name);
                         if (optstring[0] == ':') {
@@ -282,7 +284,6 @@ static int ya_getopt_longopts(int argc, char * const argv[], char *arg, const ch
                     const char *hyphens = (argv[ya_optind][1] == '-') ? "--" : "-";
 
                     ya_optind++;
-                    ya_optarg = NULL;
                     ya_optopt = opt->val;
                     ya_getopt_error(optstring, "%s: option '%s%s' doesn't allow an argument\n", argv[0], hyphens, opt->name);
                     return '?';


### PR DESCRIPTION
Not sure where optopt and optarg should be cleared. It does pass the tests against glibc 2.24.

BTW, there were some changes to the getopt implementation in glibc 2.26 such that the getopt_long_only tests no longer pass against newer glibc versions.